### PR TITLE
Allow extracting css

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,16 @@ Of course you can pass more options to it, it works the same as the `vuetify-loa
 
 **Finally, if you use both `Progressive images` and `SASS variables`, just pass both arguments after `'vuetify-loader'`. The order of the arguments does not matter**
 
+## Extract css
+To extract all Vuetify components css, pass the `extract` option.
+
+```js
+mix.js('resources/js/app.js', 'public/js')
+   .vuetify('vuetify-loader', {
+        extract: 'css/vuetify-components.css'
+   })
+```
+
 ## License
 
 The MIT License (MIT). Please see [License File](LICENSE) for more information.

--- a/src/resolveOptions.js
+++ b/src/resolveOptions.js
@@ -17,9 +17,12 @@ function resolveOptions(args) {
         }
     ]
 
+    const { extract, ...vuetifyLoaderOptions } = option
+
     return {
-        option,
-        sassArray
+        option: vuetifyLoaderOptions,
+        sassArray,
+        extract
     }
 }
 


### PR DESCRIPTION
Since the laravel-mix `extractVueStyles` does not apply to vuetify components, this PR add an `extract` option which create a new file output. This new attribute is included inside the `vuetify()` "object" parameter (which also defines the vuetify loader options).