### PR TITLE
Fix style generation with Mix v6

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,8 +53,17 @@ class Vuetify {
             use: [
                 this.withExtract()
                     ? require('mini-css-extract-plugin').loader
-                    : 'vue-style-loader',
-                'css-loader',
+                    : (mix.vue ? {
+                        loader: 'style-loader',
+                    } : 'vue-style-loader'),
+                mix.vue ? {
+                    loader: 'css-loader',
+                    options: {
+                        modules: {
+                            auto: true
+                        }
+                    }
+                } : 'css-loader',
                 ...this.addPostcssIfNeeded(),
                 {
                     loader: 'sass-loader',


### PR DESCRIPTION
This should fix #23, the style issues when using the extension with Mix v6. It is based on the changes recommended by @chris-bridges-ihpm. I've added conditional checks for the `mix.vue` function added in v6, keeping the old behavior for v5. There may be a better way to detect the mix version, but this seems to work in my limited testing.